### PR TITLE
Fix typo in Prices type for Space Category Pricing model

### DIFF
--- a/content/developers/api/connector.md
+++ b/content/developers/api/connector.md
@@ -564,7 +564,7 @@ Returns prices of a rate in the specified interval. Note that response contains 
 | Property | Type | | Description |
 | --- | --- | --- | --- |
 | `CategoryId` | string | required | Unique identifier of the [Space Category](#space-category). |
-| `Prices` | array of string | required | Prices of the rate for the space category in the covered dates. |
+| `Prices` | array of Number | required | Prices of the rate for the space category in the covered dates. |
 
 
 ### Update Rate Price


### PR DESCRIPTION
It looks based on the response that `Prices` should be an array of number rather than an array of string.